### PR TITLE
Return the `QueryBuilder` object instead of `undefined` in limit clause

### DIFF
--- a/js/typescript-library/src/queryBuilder.ts
+++ b/js/typescript-library/src/queryBuilder.ts
@@ -128,7 +128,7 @@ class QueryBuilder implements HasCondition, HasHaving, HasJoin, HasStartedBuildi
 
   limit(limit: number): CanBeBuildQuery {
     this.queryDto.limit = limit
-    return undefined
+    return this
   }
 
   orderBy(column: string, order: OrderKeyword): HasHaving {


### PR DESCRIPTION
Fixes #137 