### PR TITLE
Condition API improvements

### DIFF
--- a/js/typescript-library/src/conditions.ts
+++ b/js/typescript-library/src/conditions.ts
@@ -1,5 +1,7 @@
 import {BasicMeasure, Field, PACKAGE} from "./index"
 
+type Primitive = string | number | boolean;
+
 export interface Condition {
   readonly class: string
   readonly type: ConditionType
@@ -30,7 +32,7 @@ function toJSON(c: Condition) {
 class SingleValueCondition implements Condition {
   class: string = PACKAGE + "dto.SingleValueConditionDto"
 
-  constructor(readonly type: ConditionType, private value: any) {
+  constructor(readonly type: ConditionType, private value: Primitive) {
   }
 
   toJSON() {
@@ -58,7 +60,7 @@ class InCondition implements Condition {
   type: ConditionType = ConditionType.IN
   class: string = PACKAGE + "dto.InConditionDto"
 
-  constructor(private values: Array<any>) {
+  constructor(private values: Array<Primitive>) {
   }
 
   toJSON() {
@@ -131,31 +133,31 @@ export function isNotNull(): Condition {
   return new ConstantCondition(ConditionType.NOT_NULL)
 }
 
-export function _in(value: Array<any>): Condition {
+export function _in(value: Array<Primitive>): Condition {
   return new InCondition(value)
 }
 
-export function eq(value: any): Condition {
+export function eq(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.EQ, value)
 }
 
-export function neq(value: any): Condition {
+export function neq(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.NEQ, value)
 }
 
-export function lt(value: any): Condition {
+export function lt(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.LT, value)
 }
 
-export function le(value: any): Condition {
+export function le(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.LE, value)
 }
 
-export function gt(value: any): Condition {
+export function gt(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.GT, value)
 }
 
-export function ge(value: any): Condition {
+export function ge(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.GE, value)
 }
 

--- a/js/typescript-library/src/conditions.ts
+++ b/js/typescript-library/src/conditions.ts
@@ -29,6 +29,9 @@ function toJSON(c: Condition) {
   }
 }
 
+/**
+ * Generic condition on a string, number or boolean constant.
+ */
 class SingleValueCondition implements Condition {
   class: string = PACKAGE + "dto.SingleValueConditionDto"
 
@@ -56,6 +59,9 @@ class ConstantCondition implements Condition {
   }
 }
 
+/**
+ * In condition on a list of string, number or boolean constants.
+ */
 class InCondition implements Condition {
   type: ConditionType = ConditionType.IN
   class: string = PACKAGE + "dto.InConditionDto"
@@ -97,10 +103,16 @@ export class Criteria {
   }
 }
 
+/**
+ * Criteria on a single field. The condition can only be based on constants.
+ */
 export function criterion(field: Field, condition: Condition): Criteria {
   return new Criteria(field, undefined, undefined, condition, undefined, undefined)
 }
 
+/**
+ * Criteria based on the comparison of 2 fields.
+ */
 export function criterion_(field: Field, fieldOther: Field, conditionType: ConditionType): Criteria {
   return new Criteria(field, fieldOther, undefined, undefined, conditionType, undefined)
 }
@@ -133,34 +145,58 @@ export function isNotNull(): Condition {
   return new ConstantCondition(ConditionType.NOT_NULL)
 }
 
+/**
+ * In condition on a list of string, number or boolean constants.
+ */
 export function _in(value: Array<Primitive>): Condition {
   return new InCondition(value)
 }
 
+/**
+ * Equal condition on a string, number or boolean constant.
+ */
 export function eq(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.EQ, value)
 }
 
+/**
+ * Not equal condition on a string, number or boolean constant.
+ */
 export function neq(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.NEQ, value)
 }
 
+/**
+ * Lower than condition on a string, number or boolean constant.
+ */
 export function lt(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.LT, value)
 }
 
+/**
+ * Lower or equal condition on a string, number or boolean constant.
+ */
 export function le(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.LE, value)
 }
 
+/**
+ * Greater than condition on a string, number or boolean constant.
+ */
 export function gt(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.GT, value)
 }
 
+/**
+ * Greater or equal condition on a string, number or boolean constant.
+ */
 export function ge(value: Primitive): Condition {
   return new SingleValueCondition(ConditionType.GE, value)
 }
 
+/**
+ * Like condition on a string pattern.
+ */
 export function like(value: string): Condition {
   return new SingleValueCondition(ConditionType.LIKE, value)
 }

--- a/js/typescript-library/src/index.ts
+++ b/js/typescript-library/src/index.ts
@@ -25,7 +25,7 @@ export {
   Criteria,
   eq, neq, lt, le, gt, ge, _in, like, isNull, isNotNull,
   and, or,
-  all, any, criterion, havingCriterion,
+  all, any, criterion, criterion_, havingCriterion,
 } from './conditions'
 
 export {


### PR DESCRIPTION
Several improvements and fix on the condition API:
- The `criterion_` method is now exposed to the exterior
- the conditions now take a `Primitive` type as argument instead of `any` type
- TSDoc have been added to avoid misunderstanding methods usage