### PR TITLE
Expose compute dependencies methods of Typescript library

### DIFF
--- a/js/typescript-library/src/index.ts
+++ b/js/typescript-library/src/index.ts
@@ -55,7 +55,4 @@ export {
   default as Criteria
 } from "./criteria"
 
-export {
-  computeFieldDependencies, computeColumnSetDependencies, computePeriodDependencies,
-  computeMeasureDependencies, computeConditionDependencies, computeCriteriaDependencies
-} from "./dependencies"
+export * from "./dependencies"

--- a/js/typescript-library/src/index.ts
+++ b/js/typescript-library/src/index.ts
@@ -54,3 +54,8 @@ export {
 export {
   default as Criteria
 } from "./criteria"
+
+export {
+  computeFieldDependencies, computeColumnSetDependencies, computePeriodDependencies,
+  computeMeasureDependencies, computeConditionDependencies, computeCriteriaDependencies
+} from "./dependencies"


### PR DESCRIPTION
The compute dependencies methods weren't not exposed by the Typescript library, which prevented SquashQL users to use them properly.