### PR TITLE
[Experimental] JOIN of two SELECT statement results can guess the join condition

### DIFF
--- a/core/src/main/java/io/squashql/query/compiled/CompiledJoin.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledJoin.java
@@ -6,13 +6,16 @@ import io.squashql.query.dto.JoinType;
 public record CompiledJoin(NamedTable table, JoinType type, CompiledCriteria joinCriteria) {
 
   public String sqlExpression(QueryRewriter queryRewriter) {
-    StringBuilder statement = new StringBuilder();
-    statement.append(" ")
+    StringBuilder statement = new StringBuilder()
+            .append(" ")
             .append(this.type.name().toLowerCase())
             .append(" join ")
-            .append(this.table.sqlExpressionTableName(queryRewriter))
-            .append(" on ");
-    statement.append(joinCriteria().sqlExpression(queryRewriter));
+            .append(this.table.sqlExpressionTableName(queryRewriter));
+    if (joinCriteria() != null) {
+      statement
+              .append(" on ")
+              .append(joinCriteria().sqlExpression(queryRewriter));
+    }
 
     if (!this.table.joins().isEmpty()) {
       this.table.joins().forEach(j -> statement.append(j.sqlExpression(queryRewriter)));

--- a/core/src/main/java/io/squashql/query/dto/JoinType.java
+++ b/core/src/main/java/io/squashql/query/dto/JoinType.java
@@ -4,4 +4,5 @@ public enum JoinType {
   INNER,
   LEFT,
   FULL,
+  CROSS,
 }

--- a/js/typescript-library/src/query.ts
+++ b/js/typescript-library/src/query.ts
@@ -142,6 +142,7 @@ export enum JoinType {
   INNER = "INNER",
   LEFT = "LEFT",
   FULL = "FULL",
+  CROSS = "CROSS",
 }
 
 class Join {


### PR DESCRIPTION
If no condition is passed, the engine tries to detect the join condition based on the name of the columns of the two select statement. 

In addition to that, `JoinType.CROSS` has been added to handle the case where the two select statements have no column in common. 