### PR TITLE
Clean Field and TypeField API

### DIFF
--- a/core/src/main/java/io/squashql/query/AliasedField.java
+++ b/core/src/main/java/io/squashql/query/AliasedField.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
-public class AliasedField implements Field {
+public class AliasedField implements NamedField {
 
   public String alias;
 
@@ -19,7 +19,7 @@ public class AliasedField implements Field {
   }
 
   @Override
-  public Field as(String alias) {
+  public NamedField as(String alias) {
     return new AliasedField(alias); // does not make sense...
   }
 

--- a/core/src/main/java/io/squashql/query/BinaryOperationField.java
+++ b/core/src/main/java/io/squashql/query/BinaryOperationField.java
@@ -1,5 +1,6 @@
 package io.squashql.query;
 
+import io.squashql.type.TypedField;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
-public class BinaryOperationField implements Field {
+public class BinaryOperationField implements CompilationType<TypedField> {
 
   public BinaryOperator operator;
   public Field leftOperand;
@@ -20,11 +21,6 @@ public class BinaryOperationField implements Field {
     this.operator = operator;
     this.leftOperand = leftOperand;
     this.rightOperand = rightOperand;
-  }
-
-  @Override
-  public String name() {
-    throw new IllegalStateException("Incorrect path of execution");
   }
 
   @Override

--- a/core/src/main/java/io/squashql/query/BucketComparisonExecutor.java
+++ b/core/src/main/java/io/squashql/query/BucketComparisonExecutor.java
@@ -3,7 +3,7 @@ package io.squashql.query;
 import io.squashql.query.compiled.CompiledBucketColumnSet;
 import io.squashql.query.compiled.CompiledComparisonMeasure;
 import io.squashql.query.database.SqlUtils;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 import org.eclipse.collections.api.map.primitive.ObjectIntMap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -33,7 +33,7 @@ public class BucketComparisonExecutor extends AComparisonExecutor {
     final ObjectIntMap<String> indexByColumn;
     final Map<String, List<String>> valuesByBucket = new LinkedHashMap<>();
 
-    ShiftProcedure(CompiledBucketColumnSet cSet, Map<TypedField, String> referencePosition, ObjectIntMap<String> indexByColumn) {
+    ShiftProcedure(CompiledBucketColumnSet cSet, Map<NamedTypedField, String> referencePosition, ObjectIntMap<String> indexByColumn) {
       this.valuesByBucket.putAll(cSet.values());
       this.indexByColumn = indexByColumn;
       this.transformationByColumn = new ArrayList<>();

--- a/core/src/main/java/io/squashql/query/BucketerExecutor.java
+++ b/core/src/main/java/io/squashql/query/BucketerExecutor.java
@@ -3,14 +3,11 @@ package io.squashql.query;
 import io.squashql.query.dto.BucketColumnSetDto;
 import io.squashql.table.ColumnarTable;
 import io.squashql.table.Table;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+
+import java.util.*;
+import java.util.function.Function;
 
 public class BucketerExecutor {
 
@@ -23,10 +20,10 @@ public class BucketerExecutor {
     }
 
     MutableIntSet indexColsInPrefetch = new IntHashSet();
-    List<Field> newColumns = bucketColumnSetDto.getNewColumns();
+    List<NamedField> newColumns = bucketColumnSetDto.getNewColumns();
     List<Header> finalHeaders = new ArrayList<>(table.headers());
     for (int i = 0; i < newColumns.size(); i++) {
-      Field field = newColumns.get(i);
+      NamedField field = newColumns.get(i);
       if (!bucketColumnSetDto.getColumnsForPrefetching().contains(field)) {
         indexColsInPrefetch.add(i);
       }

--- a/core/src/main/java/io/squashql/query/ColumnSet.java
+++ b/core/src/main/java/io/squashql/query/ColumnSet.java
@@ -2,6 +2,7 @@ package io.squashql.query;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.util.List;
 
 /**
@@ -11,10 +12,10 @@ import java.util.List;
 public interface ColumnSet {
 
   @JsonIgnore
-  List<Field> getColumnsForPrefetching();
+  List<NamedField> getColumnsForPrefetching();
 
   @JsonIgnore
-  List<Field> getNewColumns();
+  List<NamedField> getNewColumns();
 
   @JsonIgnore
   ColumnSetKey getColumnSetKey();

--- a/core/src/main/java/io/squashql/query/ComparisonMeasureReferencePosition.java
+++ b/core/src/main/java/io/squashql/query/ComparisonMeasureReferencePosition.java
@@ -22,14 +22,14 @@ public class ComparisonMeasureReferencePosition implements Measure {
   @Getter
   public Measure measure;
   public ColumnSetKey columnSetKey;
-  public Map<Field, String> referencePosition;
+  public Map<NamedField, String> referencePosition;
   public Period period;
-  public List<Field> ancestors;
+  public List<NamedField> ancestors;
 
   public ComparisonMeasureReferencePosition(@NonNull String alias,
                                             @NonNull ComparisonMethod comparisonMethod,
                                             @NonNull Measure measure,
-                                            @NonNull Map<Field, String> referencePosition,
+                                            @NonNull Map<NamedField, String> referencePosition,
                                             @NonNull Period period) {
     this(alias, comparisonMethod, null, measure, referencePosition, period, null, null);
   }
@@ -37,7 +37,7 @@ public class ComparisonMeasureReferencePosition implements Measure {
   public ComparisonMeasureReferencePosition(@NonNull String alias,
                                             @NonNull ComparisonMethod comparisonMethod,
                                             @NonNull Measure measure,
-                                            @NonNull Map<Field, String> referencePosition,
+                                            @NonNull Map<NamedField, String> referencePosition,
                                             @NonNull ColumnSetKey columnSetKey) {
     this(alias, comparisonMethod, null, measure, referencePosition, null, columnSetKey, null);
   }
@@ -45,7 +45,7 @@ public class ComparisonMeasureReferencePosition implements Measure {
   public ComparisonMeasureReferencePosition(@NonNull String alias,
                                             @NonNull ComparisonMethod comparisonMethod,
                                             @NonNull Measure measure,
-                                            @NonNull List<Field> ancestors) {
+                                            @NonNull List<NamedField> ancestors) {
     this(alias, comparisonMethod, null, measure, null, null, null, ancestors);
   }
 
@@ -55,7 +55,7 @@ public class ComparisonMeasureReferencePosition implements Measure {
   public ComparisonMeasureReferencePosition(@NonNull String alias,
                                             @NonNull BiFunction<Object, Object, Object> comparisonOperator,
                                             @NonNull Measure measure,
-                                            @NonNull List<Field> ancestors) {
+                                            @NonNull List<NamedField> ancestors) {
     this(alias, null, comparisonOperator, measure, null, null, null, ancestors);
   }
 
@@ -63,10 +63,10 @@ public class ComparisonMeasureReferencePosition implements Measure {
                                              ComparisonMethod comparisonMethod,
                                              BiFunction<Object, Object, Object> comparisonOperator,
                                              Measure measure,
-                                             Map<Field, String> referencePosition,
+                                             Map<NamedField, String> referencePosition,
                                              Period period,
                                              ColumnSetKey columnSetKey,
-                                             List<Field> ancestors) {
+                                             List<NamedField> ancestors) {
     this.alias = alias;
     this.comparisonMethod = comparisonMethod;
     this.comparisonOperator = comparisonOperator;

--- a/core/src/main/java/io/squashql/query/CompilationType.java
+++ b/core/src/main/java/io/squashql/query/CompilationType.java
@@ -1,0 +1,4 @@
+package io.squashql.query;
+
+public interface CompilationType<Type> extends Field {
+}

--- a/core/src/main/java/io/squashql/query/ConstantField.java
+++ b/core/src/main/java/io/squashql/query/ConstantField.java
@@ -1,5 +1,6 @@
 package io.squashql.query;
 
+import io.squashql.type.TypedField;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -9,14 +10,9 @@ import lombok.ToString;
 @EqualsAndHashCode
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
-public class ConstantField implements Field {
+public class ConstantField implements CompilationType<TypedField> {
 
   public Object value;
-
-  @Override
-  public String name() {
-    throw new IllegalStateException("Incorrect path of execution");
-  }
 
   @Override
   public Field as(String alias) {

--- a/core/src/main/java/io/squashql/query/Field.java
+++ b/core/src/main/java/io/squashql/query/Field.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public interface Field {
 
-  String name();
-
   Field as(String alias);
 
   String alias();

--- a/core/src/main/java/io/squashql/query/FieldAndAggFunc.java
+++ b/core/src/main/java/io/squashql/query/FieldAndAggFunc.java
@@ -6,6 +6,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
 public class FieldAndAggFunc {
-  public Field field;
+  public NamedField field;
   public String aggFunc;
 }

--- a/core/src/main/java/io/squashql/query/FunctionField.java
+++ b/core/src/main/java/io/squashql/query/FunctionField.java
@@ -11,13 +11,13 @@ import static io.squashql.query.database.SqlUtils.singleOperandFunctionName;
 @EqualsAndHashCode
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
-public class FunctionField implements Field {
+public class FunctionField implements NamedField {
 
   public String function;
-  public Field field;
+  public NamedField field;
   public String alias;
 
-  public FunctionField(String function, Field field) {
+  public FunctionField(String function, NamedField field) {
     this.function = function;
     this.field = field;
   }
@@ -28,7 +28,7 @@ public class FunctionField implements Field {
   }
 
   @Override
-  public Field as(String alias) {
+  public NamedField as(String alias) {
     return new FunctionField(this.function, this.field, alias);
   }
 

--- a/core/src/main/java/io/squashql/query/Functions.java
+++ b/core/src/main/java/io/squashql/query/Functions.java
@@ -230,15 +230,15 @@ public class Functions {
     return new DoubleConstantMeasure(value);
   }
 
-  public static Field year(String field) {
+  public static NamedField year(String field) {
     return new FunctionField("YEAR", new TableField(field));
   }
 
-  public static Field quarter(String field) {
+  public static NamedField quarter(String field) {
     return new FunctionField("QUARTER", new TableField(field));
   }
 
-  public static Field month(String field) {
+  public static NamedField month(String field) {
     return new FunctionField("MONTH", new TableField(field));
   }
 }

--- a/core/src/main/java/io/squashql/query/MeasureUtils.java
+++ b/core/src/main/java/io/squashql/query/MeasureUtils.java
@@ -4,6 +4,7 @@ import io.squashql.query.compiled.*;
 import io.squashql.query.database.DatabaseQuery;
 import io.squashql.query.database.QueryRewriter;
 import io.squashql.query.dto.QueryDto;
+import io.squashql.type.NamedTypedField;
 import io.squashql.type.TableTypedField;
 import io.squashql.type.TypedField;
 import lombok.NoArgsConstructor;
@@ -42,7 +43,7 @@ public final class MeasureUtils {
       String alias = cm.getMeasure().alias();
       if (cm.ancestors != null) {
         String formula = cm.getComparisonMethod().expressionGenerator.apply(alias, alias + "(parent)");
-        return formula + ", ancestors = " + cm.ancestors.stream().map(Field::name).toList();
+        return formula + ", ancestors = " + cm.ancestors.stream().map(NamedField::name).toList();
       } else {
         String formula = cm.getComparisonMethod().expressionGenerator.apply(alias + "(current)", alias + "(reference)");
         return formula + ", reference = " + cm.referencePosition.entrySet().stream().map(e -> String.join("=", e.getKey().name(), e.getValue())).toList();
@@ -63,8 +64,8 @@ public final class MeasureUtils {
     }
 
     @Override
-    protected TypedField resolveField(Field field) {
-      return new TableTypedField(null, field.name(), String.class);
+    protected TypedField resolveAsTypedField(Field field) {
+      return new TableTypedField(null, ((NamedField) field).name(), String.class);
     }
 
     @Override
@@ -87,8 +88,8 @@ public final class MeasureUtils {
   }
 
   public static QueryExecutor.QueryScope getReadScopeComparisonMeasureReferencePosition(
-          List<TypedField> columns,
-          List<TypedField> bucketColumns,
+          List<NamedTypedField> columns,
+          List<NamedTypedField> bucketColumns,
           CompiledComparisonMeasure cm,
           QueryExecutor.QueryScope queryScope) {
     AtomicReference<CompiledCriteria> copy = new AtomicReference<>(queryScope.whereCriteria() == null ? null : CompiledCriteria.deepCopy(queryScope.whereCriteria()));

--- a/core/src/main/java/io/squashql/query/NamedField.java
+++ b/core/src/main/java/io/squashql/query/NamedField.java
@@ -1,0 +1,11 @@
+package io.squashql.query;
+
+import io.squashql.type.NamedTypedField;
+
+public interface NamedField extends CompilationType<NamedTypedField> {
+
+  String name();
+
+  NamedField as(String alias);
+
+}

--- a/core/src/main/java/io/squashql/query/PeriodComparisonExecutor.java
+++ b/core/src/main/java/io/squashql/query/PeriodComparisonExecutor.java
@@ -3,7 +3,7 @@ package io.squashql.query;
 import io.squashql.query.compiled.CompiledComparisonMeasure;
 import io.squashql.query.compiled.CompiledPeriod;
 import io.squashql.query.database.SQLTranslator;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 import org.eclipse.collections.api.map.primitive.MutableObjectIntMap;
 import org.eclipse.collections.api.map.primitive.ObjectIntMap;
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectIntHashMap;
@@ -24,7 +24,7 @@ public class PeriodComparisonExecutor extends AComparisonExecutor {
     this.cmrp = cmrp;
   }
 
-  public Map<TypedField, PeriodUnit> mapping(CompiledPeriod period) {
+  public Map<NamedTypedField, PeriodUnit> mapping(CompiledPeriod period) {
     if (period instanceof CompiledPeriod.Quarter q) {
       return Map.of(q.quarter(), QUARTER, q.year(), YEAR);
     } else if (period instanceof CompiledPeriod.Year y) {
@@ -42,14 +42,14 @@ public class PeriodComparisonExecutor extends AComparisonExecutor {
   protected BiPredicate<Object[], Header[]> createShiftProcedure(CompiledComparisonMeasure cm, ObjectIntMap<String> indexByColumn) {
     Map<PeriodUnit, String> referencePosition = new HashMap<>();
     CompiledPeriod period = this.cmrp.period();
-    Map<TypedField, PeriodUnit> mapping = mapping(period);
+    Map<NamedTypedField, PeriodUnit> mapping = mapping(period);
     MutableObjectIntMap<PeriodUnit> indexByPeriodUnit = new ObjectIntHashMap<>();
-    for (Map.Entry<TypedField, String> entry : cm.referencePosition().entrySet()) {
+    for (Map.Entry<NamedTypedField, String> entry : cm.referencePosition().entrySet()) {
       PeriodUnit pu = mapping.get(entry.getKey());
       referencePosition.put(pu, entry.getValue());
       indexByPeriodUnit.put(pu, indexByColumn.getIfAbsent(entry.getKey().name(), -1));
     }
-    for (Map.Entry<TypedField, PeriodUnit> entry : mapping.entrySet()) {
+    for (Map.Entry<NamedTypedField, PeriodUnit> entry : mapping.entrySet()) {
       PeriodUnit pu = mapping.get(entry.getKey());
       referencePosition.putIfAbsent(pu, "c"); // constant for missing ref.
       indexByPeriodUnit.getIfAbsentPut(pu, indexByColumn.getIfAbsent(entry.getKey().name(), -1));

--- a/core/src/main/java/io/squashql/query/QueryMergeExecutor.java
+++ b/core/src/main/java/io/squashql/query/QueryMergeExecutor.java
@@ -32,7 +32,7 @@ public class QueryMergeExecutor {
     return execute(first, second, joinType, t -> (ColumnarTable) TableUtils.replaceTotalCellValues((ColumnarTable) t, true), executor);
   }
 
-  public static PivotTable executePivotQueryMerge(QueryExecutor queryExecutor, QueryDto first, QueryDto second, List<Field> rows, List<Field> columns, JoinType joinType, SquashQLUser user) {
+  public static PivotTable executePivotQueryMerge(QueryExecutor queryExecutor, QueryDto first, QueryDto second, List<NamedField> rows, List<NamedField> columns, JoinType joinType, SquashQLUser user) {
     Function<QueryDto, Table> executor = query -> {
       Set<Field> columnsFromColumnSets = query.columnSets.values().stream().flatMap(cs -> cs.getNewColumns().stream()).collect(Collectors.toSet());
       return queryExecutor.executePivotQuery(
@@ -49,11 +49,11 @@ public class QueryMergeExecutor {
     };
 
     Function<Table, ColumnarTable> replaceTotalCellValuesFunction = t -> (ColumnarTable) TableUtils.replaceTotalCellValues((ColumnarTable) t,
-            rows.stream().map(Field::name).toList(),
-            columns.stream().map(Field::name).toList());
+            rows.stream().map(NamedField::name).toList(),
+            columns.stream().map(NamedField::name).toList());
     ColumnarTable table = execute(first, second, joinType, replaceTotalCellValuesFunction, executor);
     List<String> values = table.headers().stream().filter(Header::isMeasure).map(Header::name).toList();
-    return new PivotTable(table, rows.stream().map(Field::name).toList(), columns.stream().map(Field::name).toList(), values);
+    return new PivotTable(table, rows.stream().map(NamedField::name).toList(), columns.stream().map(NamedField::name).toList(), values);
   }
 
   private static ColumnarTable execute(QueryDto first,

--- a/core/src/main/java/io/squashql/query/TableField.java
+++ b/core/src/main/java/io/squashql/query/TableField.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode
 @NoArgsConstructor // For Jackson
 @AllArgsConstructor
-public class TableField implements Field {
+public class TableField implements NamedField {
 
   public String tableName;
 
@@ -58,7 +58,7 @@ public class TableField implements Field {
   }
 
   @Override
-  public Field as(String alias) {
+  public NamedField as(String alias) {
     return new TableField(this.tableName, this.fieldName, this.fullName, alias);
   }
 
@@ -71,19 +71,19 @@ public class TableField implements Field {
    * Syntactic sugar helpers.
    */
 
-  public static Field tableField(final String tableName, final String name) {
+  public static NamedField tableField(final String tableName, final String name) {
     return new TableField(tableName, name);
   }
 
-  public static Field tableField(final String name) {
+  public static NamedField tableField(final String name) {
     return new TableField(name);
   }
 
-  public static List<Field> tableFields(String tableName, List<String> fields) {
+  public static List<NamedField> tableFields(String tableName, List<String> fields) {
     return fields.stream().map(f -> new TableField(tableName, f)).collect(Collectors.toList());
   }
 
-  public static List<Field> tableFields(List<String> fields) {
+  public static List<NamedField> tableFields(List<String> fields) {
     return fields.stream().map(TableField::new).collect(Collectors.toList());
   }
 }

--- a/core/src/main/java/io/squashql/query/VectorAggMeasure.java
+++ b/core/src/main/java/io/squashql/query/VectorAggMeasure.java
@@ -9,13 +9,13 @@ import lombok.*;
 public class VectorAggMeasure implements Measure {
 
   public String alias;
-  public Field fieldToAggregate;
+  public NamedField fieldToAggregate;
   public String aggregationFunction;
-  public Field vectorAxis;
+  public NamedField vectorAxis;
   @With
   public String expression;
 
-  public VectorAggMeasure(String alias, Field fieldToAggregate, String aggregationFunction, Field vectorAxis) {
+  public VectorAggMeasure(String alias, NamedField fieldToAggregate, String aggregationFunction, NamedField vectorAxis) {
     this.alias = alias;
     this.fieldToAggregate = fieldToAggregate;
     this.aggregationFunction = aggregationFunction;

--- a/core/src/main/java/io/squashql/query/VectorTupleAggMeasure.java
+++ b/core/src/main/java/io/squashql/query/VectorTupleAggMeasure.java
@@ -16,14 +16,14 @@ public class VectorTupleAggMeasure implements Measure {
 
   public String alias;
   public List<FieldAndAggFunc> fieldToAggregateAndAggFunc;
-  public Field vectorAxis;
+  public NamedField vectorAxis;
   public Function<List<Object>, Object> transformer;
   @With
   public String expression;
 
   public VectorTupleAggMeasure(String alias,
                                List<FieldAndAggFunc> fieldToAggregateAndAggFunc,
-                               Field vectorAxis,
+                               NamedField vectorAxis,
                                Function<List<Object>, Object> transformer) {
     this.alias = alias;
     this.fieldToAggregateAndAggFunc = fieldToAggregateAndAggFunc;

--- a/core/src/main/java/io/squashql/query/builder/CanAddOrderBy.java
+++ b/core/src/main/java/io/squashql/query/builder/CanAddOrderBy.java
@@ -1,12 +1,13 @@
 package io.squashql.query.builder;
 
 import io.squashql.query.Field;
+import io.squashql.query.NamedField;
 import io.squashql.query.dto.OrderKeywordDto;
 import java.util.List;
 
 public interface CanAddOrderBy {
 
-  HasHaving orderBy(Field column, OrderKeywordDto orderKeywordDto);
+  HasHaving orderBy(NamedField column, OrderKeywordDto orderKeywordDto);
 
-  HasHaving orderBy(Field column, List<?> firstElements);
+  HasHaving orderBy(NamedField column, List<?> firstElements);
 }

--- a/core/src/main/java/io/squashql/query/builder/CanAddRollup.java
+++ b/core/src/main/java/io/squashql/query/builder/CanAddRollup.java
@@ -1,13 +1,14 @@
 package io.squashql.query.builder;
 
-import io.squashql.query.Field;
+import io.squashql.query.NamedField;
+
 import java.util.List;
 
 public interface CanAddRollup extends HasOrderBy, CanAddOrderBy, CanAddHaving {
 
-  CanAddHaving rollup(Field... columns);
+  CanAddHaving rollup(NamedField... columns);
 
-  default CanAddHaving rollup(List<Field> columns) {
-    return rollup(columns.toArray(new Field[0]));
+  default CanAddHaving rollup(List<NamedField> columns) {
+    return rollup(columns.toArray(new NamedField[0]));
   }
 }

--- a/core/src/main/java/io/squashql/query/builder/HasCondition.java
+++ b/core/src/main/java/io/squashql/query/builder/HasCondition.java
@@ -1,14 +1,15 @@
 package io.squashql.query.builder;
 
 import io.squashql.query.ColumnSet;
-import io.squashql.query.Field;
 import io.squashql.query.Measure;
+import io.squashql.query.NamedField;
+
 import java.util.Collections;
 import java.util.List;
 
 public interface HasCondition {
 
-  default CanAddRollup select(List<Field> columns, List<Measure> measures) {
+  default CanAddRollup select(List<NamedField> columns, List<Measure> measures) {
     return select(columns, Collections.emptyList(), measures);
   }
 
@@ -16,5 +17,5 @@ public interface HasCondition {
     return select(Collections.emptyList(), columnSets, measures);
   }
 
-  CanAddRollup select(List<Field> columns, List<ColumnSet> columnSets, List<Measure> measures);
+  CanAddRollup select(List<NamedField> columns, List<ColumnSet> columnSets, List<Measure> measures);
 }

--- a/core/src/main/java/io/squashql/query/builder/Query.java
+++ b/core/src/main/java/io/squashql/query/builder/Query.java
@@ -3,6 +3,7 @@ package io.squashql.query.builder;
 import io.squashql.query.ColumnSet;
 import io.squashql.query.Field;
 import io.squashql.query.Measure;
+import io.squashql.query.NamedField;
 import io.squashql.query.dto.*;
 
 import java.util.Arrays;
@@ -64,7 +65,7 @@ public class Query implements HasCondition, HasHaving, HasJoin, HasStartedBuildi
   }
 
   @Override
-  public CanAddRollup select(List<Field> columns, List<ColumnSet> columnSets, List<Measure> measures) {
+  public CanAddRollup select(List<NamedField> columns, List<ColumnSet> columnSets, List<Measure> measures) {
     addJoinToQueryDto();
     columns.forEach(this.queryDto::withColumn);
     columnSets.forEach(cs -> this.queryDto.withColumnSet(cs.getColumnSetKey(), cs));
@@ -79,19 +80,19 @@ public class Query implements HasCondition, HasHaving, HasJoin, HasStartedBuildi
   }
 
   @Override
-  public HasHaving orderBy(Field column, OrderKeywordDto orderKeywordDto) {
+  public HasHaving orderBy(NamedField column, OrderKeywordDto orderKeywordDto) {
     this.queryDto.orderBy(column, orderKeywordDto);
     return this;
   }
 
   @Override
-  public HasHaving orderBy(Field column, List<?> firstElements) {
+  public HasHaving orderBy(NamedField column, List<?> firstElements) {
     this.queryDto.orderBy(column, firstElements);
     return this;
   }
 
   @Override
-  public CanAddHaving rollup(Field... columns) {
+  public CanAddHaving rollup(NamedField... columns) {
     Arrays.stream(columns).forEach(this.queryDto::withRollup);
     return this;
   }

--- a/core/src/main/java/io/squashql/query/compiled/CompiledComparisonMeasure.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledComparisonMeasure.java
@@ -3,6 +3,7 @@ package io.squashql.query.compiled;
 import io.squashql.query.ColumnSetKey;
 import io.squashql.query.ComparisonMethod;
 import io.squashql.query.database.QueryRewriter;
+import io.squashql.type.NamedTypedField;
 import io.squashql.type.TypedField;
 
 import java.util.List;
@@ -13,7 +14,7 @@ public record CompiledComparisonMeasure(String alias,
                                         ComparisonMethod comparisonMethod,
                                         BiFunction<Object, Object, Object> comparisonOperator,
                                         CompiledMeasure measure,
-                                        Map<TypedField, String> referencePosition,
+                                        Map<NamedTypedField, String> referencePosition,
                                         CompiledPeriod period,
                                         ColumnSetKey columnSetKey,
                                         List<TypedField> ancestors) implements CompiledMeasure {

--- a/core/src/main/java/io/squashql/query/compiled/CompiledFieldAndAggFunc.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledFieldAndAggFunc.java
@@ -1,6 +1,6 @@
 package io.squashql.query.compiled;
 
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 
-public record CompiledFieldAndAggFunc(TypedField field, String aggFunc) {
+public record CompiledFieldAndAggFunc(NamedTypedField field, String aggFunc) {
 }

--- a/core/src/main/java/io/squashql/query/compiled/CompiledPeriod.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledPeriod.java
@@ -1,42 +1,42 @@
 package io.squashql.query.compiled;
 
 
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 
 import java.util.Set;
 
 public interface CompiledPeriod {
 
-  Set<TypedField> getTypedFields();
+  Set<NamedTypedField> getTypedFields();
 
-  record Month(TypedField month, TypedField year) implements CompiledPeriod {
+  record Month(NamedTypedField month, NamedTypedField year) implements CompiledPeriod {
 
     @Override
-    public Set<TypedField> getTypedFields() {
+    public Set<NamedTypedField> getTypedFields() {
       return Set.of(this.month, this.year);
     }
   }
 
-  record Quarter(TypedField quarter, TypedField year) implements CompiledPeriod {
+  record Quarter(NamedTypedField quarter, NamedTypedField year) implements CompiledPeriod {
 
     @Override
-    public Set<TypedField> getTypedFields() {
+    public Set<NamedTypedField> getTypedFields() {
       return Set.of(this.quarter, this.year);
     }
   }
 
-  record Semester(TypedField semester, TypedField year) implements CompiledPeriod {
+  record Semester(NamedTypedField semester, NamedTypedField year) implements CompiledPeriod {
 
     @Override
-    public Set<TypedField> getTypedFields() {
+    public Set<NamedTypedField> getTypedFields() {
       return Set.of(this.semester, this.year);
     }
   }
 
-  record Year(TypedField year) implements CompiledPeriod {
+  record Year(NamedTypedField year) implements CompiledPeriod {
 
     @Override
-    public Set<TypedField> getTypedFields() {
+    public Set<NamedTypedField> getTypedFields() {
       return Set.of(this.year);
     }
   }

--- a/core/src/main/java/io/squashql/query/compiled/CompiledVectorAggMeasure.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledVectorAggMeasure.java
@@ -1,12 +1,12 @@
 package io.squashql.query.compiled;
 
 import io.squashql.query.database.QueryRewriter;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 
 public record CompiledVectorAggMeasure(String alias,
-                                       TypedField fieldToAggregate,
+                                       NamedTypedField fieldToAggregate,
                                        String aggregationFunction,
-                                       TypedField vectorAxis) implements CompiledMeasure {
+                                       NamedTypedField vectorAxis) implements CompiledMeasure {
 
   @Override
   public String sqlExpression(QueryRewriter queryRewriter, boolean withAlias) {

--- a/core/src/main/java/io/squashql/query/compiled/CompiledVectorTupleAggMeasure.java
+++ b/core/src/main/java/io/squashql/query/compiled/CompiledVectorTupleAggMeasure.java
@@ -1,14 +1,14 @@
 package io.squashql.query.compiled;
 
 import io.squashql.query.database.QueryRewriter;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 
 import java.util.List;
 import java.util.function.Function;
 
 public record CompiledVectorTupleAggMeasure(String alias,
                                             List<CompiledFieldAndAggFunc> fieldToAggregateAndAggFunc,
-                                            TypedField vectorAxis,
+                                            NamedTypedField vectorAxis,
                                             Function<List<Object>, Object> transformer) implements CompiledMeasure {
 
   @Override

--- a/core/src/main/java/io/squashql/query/compiled/Evaluator.java
+++ b/core/src/main/java/io/squashql/query/compiled/Evaluator.java
@@ -6,7 +6,7 @@ import io.squashql.query.QueryExecutor.QueryPlanNodeKey;
 import io.squashql.query.comp.BinaryOperations;
 import io.squashql.store.UnknownType;
 import io.squashql.table.Table;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 import io.squashql.util.ListUtils;
 
 import java.util.ArrayList;
@@ -59,9 +59,9 @@ public class Evaluator implements BiConsumer<QueryPlanNodeKey, ExecutionContext>
       }
       executor = new BucketComparisonExecutor((CompiledBucketColumnSet) cs);
     } else if (cm.period() != null) {
-      for (TypedField field : cm.period().getTypedFields()) {
+      for (NamedTypedField field : cm.period().getTypedFields()) {
         if (!this.executionContext.columns().contains(field)) {
-          throw new IllegalArgumentException(String.format("%s is not specified in the query but is used in a comparison measure: %s", field.name(), cm));
+          throw new IllegalArgumentException(String.format("%s is not specified in the query but is used in a comparison measure: %s", field, cm));
         }
       }
       executor = new PeriodComparisonExecutor(cm);

--- a/core/src/main/java/io/squashql/query/compiled/PrefetchVisitor.java
+++ b/core/src/main/java/io/squashql/query/compiled/PrefetchVisitor.java
@@ -5,6 +5,7 @@ import io.squashql.query.QueryExecutor.QueryScope;
 import io.squashql.query.database.DatabaseQuery;
 import io.squashql.query.database.SqlUtils;
 import io.squashql.type.AliasedTypedField;
+import io.squashql.type.NamedTypedField;
 import io.squashql.type.TypedField;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.collections.impl.set.mutable.MutableSetFactoryImpl;
@@ -17,8 +18,8 @@ import static io.squashql.query.agg.AggregationFunction.*;
 @RequiredArgsConstructor
 public class PrefetchVisitor implements MeasureVisitor<Map<QueryScope, Set<CompiledMeasure>>> {
 
-  private final List<TypedField> columns;
-  private final List<TypedField> bucketColumns;
+  private final List<NamedTypedField> columns;
+  private final List<NamedTypedField> bucketColumns;
   private final QueryScope originalQueryScope;
 
   private Map<QueryScope, Set<CompiledMeasure>> empty() {
@@ -117,8 +118,8 @@ public class PrefetchVisitor implements MeasureVisitor<Map<QueryScope, Set<Compi
 
   @Override
   public Map<QueryScope, Set<CompiledMeasure>> visit(CompiledVectorTupleAggMeasure vecMeasure) {
-    TypedField vectorAxis = vecMeasure.vectorAxis();
-    List<TypedField> fieldToAggregates = vecMeasure.fieldToAggregateAndAggFunc().stream().map(CompiledFieldAndAggFunc::field).toList();
+    NamedTypedField vectorAxis = vecMeasure.vectorAxis();
+    List<NamedTypedField> fieldToAggregates = vecMeasure.fieldToAggregateAndAggFunc().stream().map(CompiledFieldAndAggFunc::field).toList();
     List<String> vectorAggFuncs = vecMeasure.fieldToAggregateAndAggFunc().stream().map(CompiledFieldAndAggFunc::aggFunc).toList();
     if (this.originalQueryScope.columns().contains(vectorAxis)) {
       Set<CompiledMeasure> m = new HashSet<>();
@@ -128,10 +129,10 @@ public class PrefetchVisitor implements MeasureVisitor<Map<QueryScope, Set<Compi
       return Map.of(this.originalQueryScope, m);
     } else {
       Set<CompiledMeasure> subQueryMeasures = new HashSet<>();
-      List<TypedField> topQuerySelectColumns = new ArrayList<>();
-      List<TypedField> subQuerySelectColumns = new ArrayList<>();
+      List<NamedTypedField> topQuerySelectColumns = new ArrayList<>();
+      List<NamedTypedField> subQuerySelectColumns = new ArrayList<>();
       Set<CompiledMeasure> topQueryMeasures = new HashSet<>();
-      for (TypedField selectColumn : this.originalQueryScope.columns()) {
+      for (NamedTypedField selectColumn : this.originalQueryScope.columns()) {
         // Here we can choose any alias but for debugging purpose, we create one from the expression.
         String alias = safeColumnAlias(SqlUtils.squashqlExpression(selectColumn));
         subQuerySelectColumns.add(selectColumn.as(alias));
@@ -172,7 +173,7 @@ public class PrefetchVisitor implements MeasureVisitor<Map<QueryScope, Set<Compi
 
       List<String> subQueryMeasureAliases = new ArrayList<>();
       for (int i = 0; i < fieldToAggregates.size(); i++) {
-        TypedField fieldToAggregate = fieldToAggregates.get(i);
+        NamedTypedField fieldToAggregate = fieldToAggregates.get(i);
         String vectorAggFunc = vectorAggFuncs.get(i);
         String subQueryMeasureAlias = safeColumnAlias(fieldToAggregate.name() + "_" + vectorAggFunc);
         subQueryMeasureAliases.add(subQueryMeasureAlias);

--- a/core/src/main/java/io/squashql/query/database/AQueryEngine.java
+++ b/core/src/main/java/io/squashql/query/database/AQueryEngine.java
@@ -4,7 +4,7 @@ import io.squashql.query.Header;
 import io.squashql.query.compiled.CompiledMeasure;
 import io.squashql.store.Datastore;
 import io.squashql.table.Table;
-import io.squashql.type.TypedField;
+import io.squashql.type.NamedTypedField;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
@@ -45,7 +45,7 @@ public abstract class AQueryEngine<T extends Datastore> implements QueryEngine<T
   protected abstract Table retrieveAggregates(DatabaseQuery query, String sql);
 
   public static <Column, Record> Pair<List<Header>, List<List<Object>>> transformToColumnFormat(
-          Collection<TypedField> typedFields,
+          Collection<NamedTypedField> typedFields,
           Collection<CompiledMeasure> measures,
           List<Column> columns,
           BiFunction<Column, String, Class<?>> columnTypeProvider,

--- a/core/src/main/java/io/squashql/query/database/DatabaseQuery.java
+++ b/core/src/main/java/io/squashql/query/database/DatabaseQuery.java
@@ -1,6 +1,10 @@
 package io.squashql.query.database;
 
-import io.squashql.query.compiled.*;
+import io.squashql.query.compiled.CompiledCriteria;
+import io.squashql.query.compiled.CompiledMeasure;
+import io.squashql.query.compiled.CompiledTable;
+import io.squashql.query.compiled.CteRecordTable;
+import io.squashql.type.NamedTypedField;
 import io.squashql.type.TypedField;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +19,7 @@ public class DatabaseQuery {
 
   public final List<CteRecordTable> cteRecordTables; // CTEs
   public final CompiledTable table;
-  public final Set<TypedField> select;
+  public final Set<NamedTypedField> select;
   public final CompiledCriteria whereCriteria;
   public final CompiledCriteria havingCriteria;
   public final List<TypedField> rollup;

--- a/core/src/main/java/io/squashql/query/dto/BucketColumnSetDto.java
+++ b/core/src/main/java/io/squashql/query/dto/BucketColumnSetDto.java
@@ -2,7 +2,7 @@ package io.squashql.query.dto;
 
 import io.squashql.query.ColumnSet;
 import io.squashql.query.ColumnSetKey;
-import io.squashql.query.Field;
+import io.squashql.query.NamedField;
 import io.squashql.query.TableField;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -18,13 +18,13 @@ import java.util.Map;
 @NoArgsConstructor // For Jackson
 public class BucketColumnSetDto implements ColumnSet {
 
-  public Field newField;
+  public NamedField newField;
 
-  public Field field;
+  public NamedField field;
 
   public Map<String, List<String>> values = new LinkedHashMap<>();
 
-  public BucketColumnSetDto(String name, Field field) {
+  public BucketColumnSetDto(String name, NamedField field) {
     this.newField = new TableField(name);
     this.field = field;
   }
@@ -35,12 +35,12 @@ public class BucketColumnSetDto implements ColumnSet {
   }
 
   @Override
-  public List<Field> getColumnsForPrefetching() {
+  public List<NamedField> getColumnsForPrefetching() {
     return List.of(this.field);
   }
 
   @Override
-  public List<Field> getNewColumns() {
+  public List<NamedField> getNewColumns() {
     return List.of(this.newField, this.field);
   }
 

--- a/core/src/main/java/io/squashql/query/dto/Period.java
+++ b/core/src/main/java/io/squashql/query/dto/Period.java
@@ -2,7 +2,8 @@ package io.squashql.query.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.squashql.query.Field;
+import io.squashql.query.NamedField;
+
 import java.util.Set;
 
 /**
@@ -17,36 +18,36 @@ import java.util.Set;
 public interface Period {
 
   @JsonIgnore
-  Set<Field> getFields();
+  Set<NamedField> getNamedFields();
 
-  record Month(Field month, Field year) implements Period {
+  record Month(NamedField month, NamedField year) implements Period {
 
     @Override
-    public Set<Field> getFields() {
+    public Set<NamedField> getNamedFields() {
       return Set.of(this.month, this.year);
     }
   }
 
-  record Quarter(Field quarter, Field year) implements Period {
+  record Quarter(NamedField quarter, NamedField year) implements Period {
 
     @Override
-    public Set<Field> getFields() {
+    public Set<NamedField> getNamedFields() {
       return Set.of(this.quarter, this.year);
     }
   }
 
-  record Semester(Field semester, Field year) implements Period {
+  record Semester(NamedField semester, NamedField year) implements Period {
 
     @Override
-    public Set<Field> getFields() {
+    public Set<NamedField> getNamedFields() {
       return Set.of(this.semester, this.year);
     }
   }
 
-  record Year(Field year) implements Period {
+  record Year(NamedField year) implements Period {
 
     @Override
-    public Set<Field> getFields() {
+    public Set<NamedField> getNamedFields() {
       return Set.of(this.year);
     }
   }

--- a/core/src/main/java/io/squashql/query/dto/PivotTableQueryDto.java
+++ b/core/src/main/java/io/squashql/query/dto/PivotTableQueryDto.java
@@ -1,6 +1,6 @@
 package io.squashql.query.dto;
 
-import io.squashql.query.Field;
+import io.squashql.query.NamedField;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -15,6 +15,6 @@ import java.util.List;
 public class PivotTableQueryDto {
 
   public QueryDto query;
-  public List<Field> rows;
-  public List<Field> columns;
+  public List<NamedField> rows;
+  public List<NamedField> columns;
 }

--- a/core/src/main/java/io/squashql/query/dto/PivotTableQueryMergeDto.java
+++ b/core/src/main/java/io/squashql/query/dto/PivotTableQueryMergeDto.java
@@ -1,6 +1,6 @@
 package io.squashql.query.dto;
 
-import io.squashql.query.Field;
+import io.squashql.query.NamedField;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -15,6 +15,6 @@ import java.util.List;
 public class PivotTableQueryMergeDto {
 
   public QueryMergeDto query;
-  public List<Field> rows;
-  public List<Field> columns;
+  public List<NamedField> rows;
+  public List<NamedField> columns;
 }

--- a/core/src/main/java/io/squashql/query/dto/QueryDto.java
+++ b/core/src/main/java/io/squashql/query/dto/QueryDto.java
@@ -28,14 +28,14 @@ public class QueryDto {
 
   public List<VirtualTableDto> virtualTableDtos = new ArrayList<>();
 
-  public List<Field> columns = new ArrayList<>();
+  public List<NamedField> columns = new ArrayList<>();
 
   public List<Field> rollupColumns = new ArrayList<>();
 
   /**
    * Internal ONLY! This field is not supposed to be set by the external API and is incompatible with {@link #rollupColumns}
    */
-  public List<List<Field>> groupingSets = new ArrayList<>();
+  public List<List<NamedField>> groupingSets = new ArrayList<>();
 
   public Map<ColumnSetKey, ColumnSet> columnSets = new LinkedHashMap<>();
 
@@ -45,13 +45,13 @@ public class QueryDto {
 
   public CriteriaDto havingCriteriaDto = null;
 
-  public Map<Field, OrderDto> orders = new LinkedHashMap<>();
+  public Map<NamedField, OrderDto> orders = new LinkedHashMap<>();
 
   public Map<String, Parameter> parameters = new HashMap<>();
 
   public int limit = -1;
 
-  public QueryDto withColumn(Field column) {
+  public QueryDto withColumn(NamedField column) {
     this.columns.add(column);
     return this;
   }
@@ -109,12 +109,12 @@ public class QueryDto {
     return this;
   }
 
-  public QueryDto orderBy(Field column, OrderKeywordDto orderKeywordDto) {
+  public QueryDto orderBy(NamedField column, OrderKeywordDto orderKeywordDto) {
     this.orders.put(column, new SimpleOrderDto(orderKeywordDto));
     return this;
   }
 
-  public QueryDto orderBy(Field column, List<?> firstElements) {
+  public QueryDto orderBy(NamedField column, List<?> firstElements) {
     this.orders.put(column, new ExplicitOrderDto(firstElements));
     return this;
   }

--- a/core/src/main/java/io/squashql/table/Table.java
+++ b/core/src/main/java/io/squashql/table/Table.java
@@ -1,7 +1,7 @@
 package io.squashql.table;
 
-import io.squashql.query.Field;
 import io.squashql.query.Header;
+import io.squashql.query.NamedField;
 import io.squashql.query.compiled.CompiledMeasure;
 import io.squashql.query.dictionary.ObjectArrayDictionary;
 import io.squashql.query.dto.QueryDto;
@@ -77,7 +77,7 @@ public interface Table extends Iterable<List<Object>> {
     return index;
   }
 
-  default IntList columnIndices(Field column) {
+  default IntList columnIndices(NamedField column) {
     int i = 0;
     MutableIntList list = MutableIntListFactoryImpl.INSTANCE.empty();
     for (Header header : headers()) {

--- a/core/src/main/java/io/squashql/type/AliasedTypedField.java
+++ b/core/src/main/java/io/squashql/type/AliasedTypedField.java
@@ -3,7 +3,7 @@ package io.squashql.type;
 import io.squashql.query.database.QueryRewriter;
 import io.squashql.store.UnknownType;
 
-public record AliasedTypedField(String alias) implements TypedField {
+public record AliasedTypedField(String alias) implements NamedTypedField {
 
   @Override
   public String sqlExpression(QueryRewriter queryRewriter) {
@@ -21,7 +21,7 @@ public record AliasedTypedField(String alias) implements TypedField {
   }
 
   @Override
-  public TypedField as(String alias) {
+  public NamedTypedField as(String alias) {
     return new AliasedTypedField(alias); // does not make sense...
   }
 }

--- a/core/src/main/java/io/squashql/type/BinaryOperationTypedField.java
+++ b/core/src/main/java/io/squashql/type/BinaryOperationTypedField.java
@@ -23,11 +23,6 @@ public record BinaryOperationTypedField(BinaryOperator operator, TypedField left
   }
 
   @Override
-  public String name() {
-    throw new IllegalStateException("Incorrect path of execution");
-  }
-
-  @Override
   public TypedField as(String alias) {
     return new BinaryOperationTypedField(this.operator, this.leftOperand, this.rightOperand, alias);
   }

--- a/core/src/main/java/io/squashql/type/ConstantTypedField.java
+++ b/core/src/main/java/io/squashql/type/ConstantTypedField.java
@@ -17,11 +17,6 @@ public record ConstantTypedField(Object value) implements TypedField {
   }
 
   @Override
-  public String name() {
-    throw new IllegalStateException("Incorrect path of execution");
-  }
-
-  @Override
   public String alias() {
     throw new IllegalStateException("Incorrect path of execution");
   }

--- a/core/src/main/java/io/squashql/type/FunctionTypedField.java
+++ b/core/src/main/java/io/squashql/type/FunctionTypedField.java
@@ -22,11 +22,6 @@ public record FunctionTypedField(TableTypedField field, String function, String 
   }
 
   @Override
-  public String name() {
-    throw new IllegalStateException("Incorrect path of execution");
-  }
-
-  @Override
   public TypedField as(String alias) {
     return new FunctionTypedField(this.field, this.function, alias);
   }

--- a/core/src/main/java/io/squashql/type/NamedTypedField.java
+++ b/core/src/main/java/io/squashql/type/NamedTypedField.java
@@ -1,0 +1,10 @@
+package io.squashql.type;
+
+public interface NamedTypedField extends TypedField {
+
+  String name();
+
+  @Override
+  NamedTypedField as(String alias);
+
+}

--- a/core/src/main/java/io/squashql/type/TableTypedField.java
+++ b/core/src/main/java/io/squashql/type/TableTypedField.java
@@ -5,7 +5,7 @@ import io.squashql.query.database.QueryRewriter;
 
 import java.util.Objects;
 
-public record TableTypedField(String store, String name, Class<?> type, String alias) implements TypedField {
+public record TableTypedField(String store, String name, Class<?> type, String alias) implements NamedTypedField {
 
   public TableTypedField {
     Objects.requireNonNull(name);
@@ -26,7 +26,12 @@ public record TableTypedField(String store, String name, Class<?> type, String a
   }
 
   @Override
-  public TypedField as(String alias) {
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public NamedTypedField as(String alias) {
     return new TableTypedField(this.store, this.name, this.type, alias);
   }
 }

--- a/core/src/main/java/io/squashql/type/TypedField.java
+++ b/core/src/main/java/io/squashql/type/TypedField.java
@@ -1,16 +1,12 @@
 package io.squashql.type;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.squashql.query.database.QueryRewriter;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public interface TypedField {
 
   String sqlExpression(QueryRewriter queryRewriter);
 
   Class<?> type();
-
-  String name();
 
   String alias();
 

--- a/core/src/main/java/io/squashql/util/Queries.java
+++ b/core/src/main/java/io/squashql/util/Queries.java
@@ -3,6 +3,7 @@ package io.squashql.util;
 import io.squashql.query.ColumnSet;
 import io.squashql.query.ColumnSetKey;
 import io.squashql.query.Field;
+import io.squashql.query.NamedField;
 import io.squashql.query.dto.*;
 
 import java.util.*;
@@ -16,7 +17,7 @@ public final class Queries {
   }
 
   public static Map<String, Comparator<?>> getComparators(QueryDto queryDto) {
-    Map<Field, OrderDto> orders = queryDto.orders;
+    Map<NamedField, OrderDto> orders = queryDto.orders;
     Map<String, Comparator<?>> res = new HashMap<>();
     orders.forEach((c, order) -> {
       if (order instanceof SimpleOrderDto so) {

--- a/core/src/test/java/io/squashql/jackson/TestQueryS13n.java
+++ b/core/src/test/java/io/squashql/jackson/TestQueryS13n.java
@@ -193,8 +193,8 @@ public class TestQueryS13n {
 
   @Test
   void testPivotTableDto() {
-    Field f1 = tableField("f1");
-    Field f2 = tableField("f2");
+    NamedField f1 = tableField("f1");
+    NamedField f2 = tableField("f2");
     QueryDto query = Query.from("table")
             .select(List.of(f1, f2), List.of(), List.of())
             .build();

--- a/core/src/test/java/io/squashql/query/ATestBucketComparison.java
+++ b/core/src/test/java/io/squashql/query/ATestBucketComparison.java
@@ -69,7 +69,7 @@ public abstract class ATestBucketComparison extends ABaseTestQuery {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void testAbsoluteDifferenceWithFirst(boolean fullName) {
-    Field scenario = fullName ? new TableField(this.storeName, SCENARIO_FIELD_NAME) : new TableField(SCENARIO_FIELD_NAME);
+    NamedField scenario = fullName ? new TableField(this.storeName, SCENARIO_FIELD_NAME) : new TableField(SCENARIO_FIELD_NAME);
     BucketColumnSetDto bucket = new BucketColumnSetDto(this.groupOfScenario, scenario)
             .withNewBucket("group1", List.of(MAIN_SCENARIO_NAME, "s1"))
             .withNewBucket("group2", List.of(MAIN_SCENARIO_NAME, "s2"))

--- a/core/src/test/java/io/squashql/query/ATestDocBucketComparison.java
+++ b/core/src/test/java/io/squashql/query/ATestDocBucketComparison.java
@@ -1,20 +1,21 @@
 package io.squashql.query;
 
-import static io.squashql.query.TableField.tableField;
-import static io.squashql.transaction.DataLoader.MAIN_SCENARIO_NAME;
-import static io.squashql.transaction.DataLoader.SCENARIO_FIELD_NAME;
-
 import io.squashql.TestClass;
 import io.squashql.query.builder.Query;
 import io.squashql.query.dto.BucketColumnSetDto;
 import io.squashql.query.dto.QueryDto;
 import io.squashql.table.Table;
 import io.squashql.type.TableTypedField;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.squashql.query.TableField.tableField;
+import static io.squashql.transaction.DataLoader.MAIN_SCENARIO_NAME;
+import static io.squashql.transaction.DataLoader.SCENARIO_FIELD_NAME;
 
 /**
  * This test class is used to verify and print tables for the documentation. Nothing is asserted in those tests this is
@@ -44,7 +45,7 @@ public abstract class ATestDocBucketComparison extends ABaseTestQuery {
   @Test
   void test() {
     Measure revenue = new ExpressionMeasure("revenue", "sum(saleprice * loavessold)");
-    final Field scenario = tableField(SCENARIO_FIELD_NAME);
+    final NamedField scenario = tableField(SCENARIO_FIELD_NAME);
     BucketColumnSetDto bucketCS = new BucketColumnSetDto("group", scenario)
             .withNewBucket("group1", List.of(MAIN_SCENARIO_NAME, "s1"))
             .withNewBucket("group2", List.of(MAIN_SCENARIO_NAME, "s2"))

--- a/core/src/test/java/io/squashql/query/ATestExperimentalQueryResultMerge.java
+++ b/core/src/test/java/io/squashql/query/ATestExperimentalQueryResultMerge.java
@@ -22,13 +22,13 @@ public abstract class ATestExperimentalQueryResultMerge extends ABaseTestQuery {
 
   String storeA = "StoreA" + getClass().getSimpleName().toLowerCase();
   String storeB = "StoreB" + getClass().getSimpleName().toLowerCase();
-  Field category = new TableField(this.storeA, "category");
-  Field idA = new TableField(this.storeA, "idA");
-  Field idStoreA = new TableField(this.storeA, "id");
-  Field priceA = new TableField(this.storeA, "priceA");
-  Field idB = new TableField(this.storeB, "idB");
-  Field idStoreB = new TableField(this.storeB, "id");
-  Field priceB = new TableField(this.storeB, "priceB");
+  NamedField category = new TableField(this.storeA, "category");
+  NamedField idA = new TableField(this.storeA, "idA");
+  NamedField idStoreA = new TableField(this.storeA, "id");
+  NamedField priceA = new TableField(this.storeA, "priceA");
+  NamedField idB = new TableField(this.storeB, "idB");
+  NamedField idStoreB = new TableField(this.storeB, "id");
+  NamedField priceB = new TableField(this.storeB, "priceB");
   Measure priceASum = Functions.sum("priceA", this.priceA);
   Measure priceBSum = Functions.sum("priceB", this.priceB);
 
@@ -155,13 +155,13 @@ public abstract class ATestExperimentalQueryResultMerge extends ABaseTestQuery {
    */
   @Test
   void testLeftJoinWithCommonColumnsAndSameNamesWithAliases() {
-    Field categoryAliased = this.category.as("category_aliased");
+    NamedField categoryAliased = this.category.as("category_aliased");
     QueryDto queryL = Query
             .from(this.storeA)
             .select(List.of(categoryAliased, this.idStoreA), List.of(this.priceASum))
             .build();
 
-    Field idStoreBAliased = this.idStoreB.as("id_aliased");
+    NamedField idStoreBAliased = this.idStoreB.as("id_aliased");
     QueryDto queryR = Query
             .from(this.storeB)
             .select(List.of(idStoreBAliased), List.of(this.priceBSum))
@@ -215,8 +215,8 @@ public abstract class ATestExperimentalQueryResultMerge extends ABaseTestQuery {
   void testLeftJoinWithoutCriteriaWithColumnsInCommon() {
     String firstKey = "first_key";
     String secondKey = "second_key";
-    Field idA = this.idA.as(firstKey);
-    Field idStoreA = this.idStoreA.as(secondKey);
+    NamedField idA = this.idA.as(firstKey);
+    NamedField idStoreA = this.idStoreA.as(secondKey);
     QueryDto queryL = Query
             .from(this.storeA)
             .select(List.of(idA, idStoreA), List.of(this.priceASum))
@@ -266,7 +266,7 @@ public abstract class ATestExperimentalQueryResultMerge extends ABaseTestQuery {
 
   @Test
   void testWithSubQueries() {
-    Field idAliasedA = this.idStoreA.as("id_aliased_a");
+    NamedField idAliasedA = this.idStoreA.as("id_aliased_a");
     QueryDto queryL = Query
             .from(this.storeA)
             .select(List.of(this.idA, idAliasedA), List.of(this.priceASum))
@@ -277,7 +277,7 @@ public abstract class ATestExperimentalQueryResultMerge extends ABaseTestQuery {
             .select(List.of(new AliasedField(idAliasedA.alias())), List.of(sum("priceA2", new AliasedField(this.priceASum.alias()))))
             .build();
 
-    Field idAliasedB = this.idStoreB.as("id_aliased_b");
+    NamedField idAliasedB = this.idStoreB.as("id_aliased_b");
     QueryDto queryR = Query
             .from(this.storeB)
             .select(List.of(this.idB, idAliasedB), List.of(this.priceBSum))

--- a/core/src/test/java/io/squashql/query/ATestParentComparison.java
+++ b/core/src/test/java/io/squashql/query/ATestParentComparison.java
@@ -57,7 +57,7 @@ public abstract class ATestParentComparison extends ABaseTestQuery {
   @Test
   void testSimple() {
     Measure pop = Functions.sum("population", this.population);
-    final List<Field> fields = List.of(this.continent, this.country, this.city);
+    final List<NamedField> fields = List.of(this.continent, this.country, this.city);
     ComparisonMeasureReferencePosition pOp = new ComparisonMeasureReferencePosition("percentOfParent", DIVIDE, pop, fields);
     QueryDto query = Query
             .from(this.storeName)
@@ -97,7 +97,7 @@ public abstract class ATestParentComparison extends ABaseTestQuery {
   @Test
   void testClearFilter() {
     Measure pop = Functions.sum("population", this.population);
-    List<Field> fields = List.of(this.continent, this.country, this.city);
+    List<NamedField> fields = List.of(this.continent, this.country, this.city);
     ComparisonMeasureReferencePosition pOp = new ComparisonMeasureReferencePosition("percentOfParent", DIVIDE, pop, fields);
     QueryDto query = Query
             .from(this.storeName)
@@ -164,7 +164,7 @@ public abstract class ATestParentComparison extends ABaseTestQuery {
     // parent with a measure computed by SquashQL.
     Measure pop = Functions.sum("populationsum", this.population);
     Measure pop2 = Functions.plus("pop2", pop, Functions.integer(2));
-    List<Field> select = List.of(this.continent, this.country, this.city);
+    List<NamedField> select = List.of(this.continent, this.country, this.city);
     ComparisonMeasureReferencePosition pOp = new ComparisonMeasureReferencePosition("percentOfParent", DIVIDE, pop, select);
     ComparisonMeasureReferencePosition pOp2 = new ComparisonMeasureReferencePosition("percentOfParent2", DIVIDE, pop2, select);
     QueryDto query = Query
@@ -184,7 +184,7 @@ public abstract class ATestParentComparison extends ABaseTestQuery {
   @Test
   void testSimpleWithTotals() {
     Measure pop = Functions.sum("population", this.population);
-    List<Field> fields = List.of(this.continent, this.country, this.city);
+    List<NamedField> fields = List.of(this.continent, this.country, this.city);
     ComparisonMeasureReferencePosition pOp = new ComparisonMeasureReferencePosition("percentOfParent", DIVIDE, pop, fields);
     QueryDto query = Query
             .from(this.storeName)

--- a/core/src/test/java/io/squashql/query/ATestParentComparisonWithOtherColumn.java
+++ b/core/src/test/java/io/squashql/query/ATestParentComparisonWithOtherColumn.java
@@ -50,7 +50,7 @@ public abstract class ATestParentComparisonWithOtherColumn extends ABaseTestQuer
   @Test
   void testSimple() {
     Measure amount = Functions.sum("amount", "amount");
-    final List<Field> fields = tableFields(List.of("continent", "country", "city"));
+    final List<NamedField> fields = tableFields(List.of("continent", "country", "city"));
     ComparisonMeasureReferencePosition pOp = new ComparisonMeasureReferencePosition("percentOfParent", ComparisonMethod.DIVIDE, amount, fields);
     QueryDto query = Query
             .from(this.storeName)

--- a/core/src/test/java/io/squashql/query/ATestPivotTable.java
+++ b/core/src/test/java/io/squashql/query/ATestPivotTable.java
@@ -90,7 +90,7 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
   @Test
   void testRollupEquivalent() {
     Measure amount = Functions.sum("amount", "amount");
-    final List<Field> fields = tableFields(List.of("continent", "country", "city"));
+    final List<NamedField> fields = tableFields(List.of("continent", "country", "city"));
     QueryDto queryWithoutRollup = Query
             .from(this.storeSpending)
             .select(fields, List.of(amount))
@@ -126,8 +126,8 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
             .where(criterion("city", in("la", "london"))) // to reduce size of the output
             .select(tableFields(List.of("spending category", "city")), List.of(amount))
             .build();
-    List<Field> rows = tableFields(List.of("city"));
-    List<Field> columns = tableFields(List.of("spending category"));
+    List<NamedField> rows = tableFields(List.of("city"));
+    List<NamedField> columns = tableFields(List.of("spending category"));
     PivotTable result = this.executor.executePivotQuery(new PivotTableQueryDto(query, rows, columns));
 
     Assertions.assertThat(result.table).containsExactly(
@@ -188,8 +188,8 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
 
   @Test
   void testGroupingOneColumnEachAxis() {
-    final Field group = tableField("group");
-    final Field country = tableField("country");
+    final NamedField group = tableField("group");
+    final NamedField country = tableField("country");
     BucketColumnSetDto bucketCS = new BucketColumnSetDto("group", country)
             .withNewBucket("european", List.of("uk", "france"))
             .withNewBucket("anglophone", List.of("usa", "uk"))
@@ -230,8 +230,8 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
 
   @Test
   void testGroupingMultipleColumns(TestInfo testInfo) {
-    final Field group = tableField("group");
-    final Field country = tableField("country");
+    final NamedField group = tableField("group");
+    final NamedField country = tableField("country");
     BucketColumnSetDto bucketCS = new BucketColumnSetDto("group", country)
             .withNewBucket("european", List.of("uk", "france"))
             .withNewBucket("anglophone", List.of("usa", "uk"))
@@ -283,8 +283,8 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
             .select(tableFields(List.of("spending category", "spending subcategory", "continent", "country", "city")), measures)
             .rollup(tableField("spending category")) // rollup is not supported with the pivot table API
             .build();
-    List<Field> rows = tableFields(List.of("continent", "country", "city"));
-    List<Field> columns = tableFields(List.of("spending category", "spending subcategory"));
+    List<NamedField> rows = tableFields(List.of("continent", "country", "city"));
+    List<NamedField> columns = tableFields(List.of("spending category", "spending subcategory"));
     Assertions.assertThatThrownBy(() -> this.executor.executePivotQuery(new PivotTableQueryDto(query, rows, columns)))
             .hasMessage("Rollup is not supported by this API");
   }
@@ -297,14 +297,14 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
             .from(this.storeSpending)
             .select(tableFields(List.of("spending category", "spending subcategory", "continent", "country", "city")), measures)
             .build();
-    List<Field> rowsWithoutContinent = tableFields(List.of("country", "city"));
-    List<Field> columns = tableFields(List.of("spending category", "spending subcategory"));
+    List<NamedField> rowsWithoutContinent = tableFields(List.of("country", "city"));
+    List<NamedField> columns = tableFields(List.of("spending category", "spending subcategory"));
     // continent is missing despite the fact it is in the select
     Assertions.assertThatThrownBy(() -> this.executor.executePivotQuery(new PivotTableQueryDto(query, rowsWithoutContinent, columns)))
             .hasMessage("[continent] in select but not on rows or columns. Please add those fields on one axis");
 
-    List<Field> rows = tableFields(List.of("continent", "country", "city"));
-    List<Field> columnsWithoutContinent = tableFields(List.of("spending category"));
+    List<NamedField> rows = tableFields(List.of("continent", "country", "city"));
+    List<NamedField> columnsWithoutContinent = tableFields(List.of("spending category"));
     // spending subcategory is missing despite the fact it is in the select
     Assertions.assertThatThrownBy(() -> this.executor.executePivotQuery(new PivotTableQueryDto(query, rows, columnsWithoutContinent)))
             .hasMessage("[spending subcategory] in select but not on rows or columns. Please add those fields on one axis");
@@ -318,8 +318,8 @@ public abstract class ATestPivotTable extends ABaseTestQuery {
             .from(this.storeSpending)
             .select(tableFields(List.of("spending category", "spending subcategory", "continent", "country", "city")), measures)
             .build();
-    List<Field> rows = tableFields(List.of("unknown", "continent", "country", "city"));
-    List<Field> columns = tableFields(List.of("spending category", "spending subcategory"));
+    List<NamedField> rows = tableFields(List.of("unknown", "continent", "country", "city"));
+    List<NamedField> columns = tableFields(List.of("spending category", "spending subcategory"));
     // continent is missing despite the fact it is in the select
     Assertions.assertThatThrownBy(() -> this.executor.executePivotQuery(new PivotTableQueryDto(query, rows, columns)))
             .hasMessage("[unknown] on rows or columns by not in select. Please add those fields in select");

--- a/core/src/test/java/io/squashql/query/ATestQueryCache.java
+++ b/core/src/test/java/io/squashql/query/ATestQueryCache.java
@@ -499,8 +499,8 @@ public abstract class ATestQueryCache extends ABaseTestQuery {
 
   @Test
   void testQueryPivotTable() {
-    final Field category = tableField("category");
-    final Field ean = tableField("ean");
+    final NamedField category = tableField("category");
+    final NamedField ean = tableField("ean");
     QueryDto q = Query
             .from(this.storeName)
             .select(List.of(category, ean), List.of(sum("ca", "price")))
@@ -521,7 +521,7 @@ public abstract class ATestQueryCache extends ABaseTestQuery {
 
   @Test
   void testWithNullValueAndRollup() {
-    List<Field> columns = tableFields(List.of("category", "ean"));
+    List<NamedField> columns = tableFields(List.of("category", "ean"));
     QueryDto q1 = Query
             .from(this.other)
             .select(columns, List.of(CountMeasure.INSTANCE))

--- a/core/src/test/java/io/squashql/query/ATestQueryExecutor.java
+++ b/core/src/test/java/io/squashql/query/ATestQueryExecutor.java
@@ -81,7 +81,7 @@ public abstract class ATestQueryExecutor extends ABaseTestQuery {
 
   @Test
   void testQueryWildcardWithAliases() {
-    Field scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_alias");
+    NamedField scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_alias");
     QueryDto query = Query
             .from(this.storeName)
             .select(List.of(scenario), List.of(sum("p", "price"), sum("q", "quantity")))
@@ -114,8 +114,8 @@ public abstract class ATestQueryExecutor extends ABaseTestQuery {
 
   @Test
   void testQueryWildcardWithFullRollupWithAliases() {
-    Field scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_alias");
-    Field category = tableField("category").as("category_alias");
+    NamedField scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_alias");
+    NamedField category = tableField("category").as("category_alias");
     QueryDto query = Query
             .from(this.storeName)
             .where(scenario, eq(MAIN_SCENARIO_NAME)) // use a filter to have a small output table
@@ -384,7 +384,7 @@ public abstract class ATestQueryExecutor extends ABaseTestQuery {
 
   @Test
   void testConditionAliasedField() {
-    Field scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_aliased");
+    NamedField scenario = tableField(SCENARIO_FIELD_NAME).as("scenario_aliased");
     QueryDto query = Query
             .from(this.storeName)
             .where(criterion(scenario, eq("s1")))

--- a/core/src/test/java/io/squashql/query/ATestSubQuery.java
+++ b/core/src/test/java/io/squashql/query/ATestSubQuery.java
@@ -59,7 +59,7 @@ public abstract class ATestSubQuery extends ABaseTestQuery {
 
   @Test
   void testSubQueryWithAlias() {
-    Field tableField = new TableField("name").as("student_name");
+    NamedField tableField = new TableField("name").as("student_name");
     QueryDto subQuery = Query.from("student")
             .select(List.of(tableField), List.of(sum("score_sum", "score")))
             .build();

--- a/core/src/test/java/io/squashql/query/ATestVectorAggregation.java
+++ b/core/src/test/java/io/squashql/query/ATestVectorAggregation.java
@@ -39,10 +39,10 @@ public abstract class ATestVectorAggregation extends ABaseTestQuery {
   static final LocalDate d2 = LocalDate.of(2023, 1, 2);
   static final LocalDate d3 = LocalDate.of(2023, 1, 3);
   final String storeName = "store" + getClass().getSimpleName().toLowerCase();
-  final Field ean = new TableField(this.storeName, "ean");
-  final Field competitor = new TableField(this.storeName, "competitor");
-  final Field value = new TableField(this.storeName, "price");
-  final Field date = new TableField(this.storeName, "date");
+  final NamedField ean = new TableField(this.storeName, "ean");
+  final NamedField competitor = new TableField(this.storeName, "competitor");
+  final NamedField value = new TableField(this.storeName, "price");
+  final NamedField date = new TableField(this.storeName, "date");
   GlobalCache queryCache;
 
   @Override
@@ -375,10 +375,10 @@ public abstract class ATestVectorAggregation extends ABaseTestQuery {
 
   @Test
   void testPivotTable() {
-    Field ean = new TableField(this.storeName, "ean");
-    Field competitor = new TableField(this.storeName, "competitor");
-    Field value = new TableField(this.storeName, "price");
-    Field date = new TableField(this.storeName, "date");
+    NamedField ean = new TableField(this.storeName, "ean");
+    NamedField competitor = new TableField(this.storeName, "competitor");
+    NamedField value = new TableField(this.storeName, "price");
+    NamedField date = new TableField(this.storeName, "date");
 
     Measure vector = new VectorAggMeasure("vector", value, SUM, date);
     QueryDto query = Query

--- a/core/src/test/java/io/squashql/query/ATestVectorAggregationDataType.java
+++ b/core/src/test/java/io/squashql/query/ATestVectorAggregationDataType.java
@@ -69,9 +69,9 @@ public abstract class ATestVectorAggregationDataType extends ABaseTestQuery {
   }
 
   void assertVectorType(String type) {
-    Field ean = new TableField(this.storeName, "ean");
-    Field valueType = new TableField(this.storeName, "value" + type);
-    Field date = new TableField(this.storeName, "date");
+    NamedField ean = new TableField(this.storeName, "ean");
+    NamedField valueType = new TableField(this.storeName, "value" + type);
+    NamedField date = new TableField(this.storeName, "date");
 
     Measure vector = new VectorAggMeasure("vector", valueType, SUM, date);
     QueryDto query = Query

--- a/core/src/test/java/io/squashql/query/ATestVectorOperation.java
+++ b/core/src/test/java/io/squashql/query/ATestVectorOperation.java
@@ -37,10 +37,10 @@ public abstract class ATestVectorOperation extends ABaseTestQuery {
   static final int day = 5;
   static final int month = 4;
   final String storeName = "mystore" + getClass().getSimpleName().toLowerCase();
-  final Field competitor = new TableField(this.storeName, "competitor");
-  final Field ean = new TableField(this.storeName, "ean");
-  final Field price = new TableField(this.storeName, "price");
-  final Field date = new TableField(this.storeName, "date");
+  final NamedField competitor = new TableField(this.storeName, "competitor");
+  final NamedField ean = new TableField(this.storeName, "ean");
+  final NamedField price = new TableField(this.storeName, "price");
+  final NamedField date = new TableField(this.storeName, "date");
 
   @Override
   protected Map<String, List<TableTypedField>> getFieldsByStore() {
@@ -178,7 +178,7 @@ public abstract class ATestVectorOperation extends ABaseTestQuery {
   @Test
   void testParentComparison() {
     Measure vector = new VectorTupleAggMeasure("vector", List.of(new FieldAndAggFunc(this.price, SUM), new FieldAndAggFunc(this.date, ANY_VALUE)), this.date, null);
-    List<Field> fields = List.of(this.competitor, this.ean);
+    List<NamedField> fields = List.of(this.competitor, this.ean);
     BiFunction<Object, Object, Object> operator = (a, b) -> {
       DoubleList currentValue = (DoubleList) ((List) a).get(0);
       DoubleList parentValue = (DoubleList) ((List) b).get(0);

--- a/core/src/test/java/io/squashql/query/TestMeasures.java
+++ b/core/src/test/java/io/squashql/query/TestMeasures.java
@@ -56,7 +56,7 @@ public class TestMeasures {
             period);
     Measure kpi = plus("KPI", ebidtaRatio, growth);
 
-    Map<Field, String> referencePosition = new LinkedHashMap<>();
+    Map<NamedField, String> referencePosition = new LinkedHashMap<>();
     referencePosition.put(tableField("scenario encrypted"), "s-1");
     referencePosition.put(tableField("group"), "g");
     ComparisonMeasureReferencePosition kpiComp = new ComparisonMeasureReferencePosition(

--- a/core/src/test/java/io/squashql/query/TestSQLTranslator.java
+++ b/core/src/test/java/io/squashql/query/TestSQLTranslator.java
@@ -33,20 +33,20 @@ public class TestSQLTranslator {
     }
 
     @Override
-    protected TypedField resolveField(Field field) {
+    protected TypedField resolveAsTypedField(Field field) {
       Function<String, Class<?>> type = f -> switch (f) {
         case "pnl", BASE_STORE_NAME + "." + "pnl" -> double.class;
         case "delta", BASE_STORE_NAME + "." + "delta" -> Double.class;
         default -> String.class;
       };
       if (field instanceof BinaryOperationField bf) {
-        return new BinaryOperationTypedField(bf.operator, resolveField(bf.leftOperand), resolveField(bf.rightOperand), field.alias());
+        return new BinaryOperationTypedField(bf.operator, resolveAsTypedField(bf.leftOperand), resolveAsTypedField(bf.rightOperand), field.alias());
       } else if (field instanceof ConstantField cf) {
         return new ConstantTypedField(cf.value);
       } else if (field instanceof AliasedField) {
         return new AliasedTypedField(field.alias());
       }
-      String[] split = field.name().split("\\.");
+      String[] split = ((NamedField) field).name().split("\\.");
       if (split.length > 1) {
         String tableName = split[0];
         String fieldNameInTable = split[1];
@@ -124,7 +124,7 @@ public class TestSQLTranslator {
   }
 
   private TypedField compileField(Field field) {
-    return new TestResolver(new QueryDto().table("fake")).resolveField(field);
+    return new TestResolver(new QueryDto().table("fake")).resolveAsTypedField(field);
   }
 
   private DatabaseQuery compileQuery(QueryDto query, Map<String, Store> stores) {
@@ -202,8 +202,8 @@ public class TestSQLTranslator {
 
   @Test
   void testWithFullRollup() {
-    final Field scenario = tableField(SCENARIO_FIELD_NAME);
-    final Field type = tableField("type");
+    final NamedField scenario = tableField(SCENARIO_FIELD_NAME);
+    final NamedField type = tableField("type");
     final QueryDto query = new QueryDto()
             .withColumn(scenario)
             .withColumn(type)
@@ -222,8 +222,8 @@ public class TestSQLTranslator {
 
   @Test
   void testWithFullRollupWithFullName() {
-    final Field scenario = tableField(SqlUtils.getFieldFullName(BASE_STORE_NAME, SCENARIO_FIELD_NAME));
-    final Field type = tableField(SqlUtils.getFieldFullName(BASE_STORE_NAME, "type"));
+    final NamedField scenario = tableField(SqlUtils.getFieldFullName(BASE_STORE_NAME, SCENARIO_FIELD_NAME));
+    final NamedField type = tableField(SqlUtils.getFieldFullName(BASE_STORE_NAME, "type"));
     final QueryDto query = new QueryDto()
             .withColumn(scenario)
             .withColumn(type)
@@ -482,8 +482,8 @@ public class TestSQLTranslator {
 
   @Test
   void testGroupingSets() {
-    final Field a = tableField("a");
-    final Field b = tableField("b");
+    final NamedField a = tableField("a");
+    final NamedField b = tableField("b");
     final QueryDto query = new QueryDto()
             .withColumn(a)
             .withColumn(b)

--- a/server/src/test/java/io/squashql/client/HttpClientQuerierTest.java
+++ b/server/src/test/java/io/squashql/client/HttpClientQuerierTest.java
@@ -187,8 +187,8 @@ public class HttpClientQuerierTest {
     PivotTableQueryDto pivotTableQuery = new PivotTableQueryDto(query, tableFields(List.of("pdv")), tableFields(List.of("ean")));
     PivotTableQueryResultDto response = this.querier.run(pivotTableQuery);
 
-    Assertions.assertThat(response.rows).containsExactlyElementsOf(pivotTableQuery.rows.stream().map(Field::name).toList());
-    Assertions.assertThat(response.columns).containsExactlyElementsOf(pivotTableQuery.columns.stream().map(Field::name).toList());
+    Assertions.assertThat(response.rows).containsExactlyElementsOf(pivotTableQuery.rows.stream().map(NamedField::name).toList());
+    Assertions.assertThat(response.columns).containsExactlyElementsOf(pivotTableQuery.columns.stream().map(NamedField::name).toList());
     Assertions.assertThat(response.values).containsExactlyElementsOf(List.of(CountMeasure.INSTANCE.alias));
     Assertions.assertThat(response.queryResult.table.rows)
             .containsExactly(

--- a/server/src/test/java/io/squashql/js/TestJavascriptLibrary.java
+++ b/server/src/test/java/io/squashql/js/TestJavascriptLibrary.java
@@ -29,8 +29,8 @@ public class TestJavascriptLibrary {
     table.join(refTable, JoinType.INNER, criterion("fromField", "toField", ConditionType.EQ));
     table.join(new TableDto("a"), JoinType.LEFT, criterion("a" + ".a_id", "myTable" + ".id", ConditionType.EQ));
 
-    Field a = tableField("a");
-    Field b = tableField("b").as("b_alias");
+    NamedField a = tableField("a");
+    NamedField b = tableField("b").as("b_alias");
     QueryDto q = new QueryDto()
             .table(table)
             .withColumn(a)

--- a/server/src/test/java/io/squashql/spring/web/rest/QueryControllerTest.java
+++ b/server/src/test/java/io/squashql/spring/web/rest/QueryControllerTest.java
@@ -23,7 +23,8 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import static io.squashql.query.Functions.*;
+import static io.squashql.query.Functions.criterion;
+import static io.squashql.query.Functions.sum;
 import static io.squashql.query.TableField.tableField;
 import static io.squashql.query.TableField.tableFields;
 import static io.squashql.transaction.DataLoader.MAIN_SCENARIO_NAME;
@@ -305,8 +306,8 @@ public class QueryControllerTest {
 
   @Test
   void testExperimentalQueryJoin() throws Exception {
-    Field ean = new TableField("our_prices", "ean");
-    Field competitorEan = new TableField("their_prices", "competitor_ean");
+    NamedField ean = new TableField("our_prices", "ean");
+    NamedField competitorEan = new TableField("their_prices", "competitor_ean");
     var query1 = Query
             .from("our_prices")
             .select(List.of(ean), List.of(sum("price_sum", "price")))


### PR DESCRIPTION
Resolves: https://github.com/squashql/squashql/issues/228 

Removing `TypedField#name()` proves to be nearly impossible as it's used for the following use cases:

- Data loading and schema creation (this can easily be resolved by creating a dedicated pojo for this purpose)
- Aliasing vectors during prefetch (can be removed by using a dedicated internal alias)
- Generating SQL for function and table field (we can keep the name only in these two)
