### PR TITLE
Add missing BIGINT[] type to DuckDB type converter

### DIFF
--- a/duckdb/src/main/java/io/squashql/DuckDBUtil.java
+++ b/duckdb/src/main/java/io/squashql/DuckDBUtil.java
@@ -33,7 +33,7 @@ public final class DuckDBUtil {
       // See DuckDBResultSetMetaData#TypeNameToType
       if (columnTypeName.equals("DOUBLE[]") || columnTypeName.equals("FLOAT[]")) {
         return Lists.DoubleList.class;
-      } else if (columnTypeName.equals("LONG[]") || columnTypeName.equals("HUGEINT[]") || columnTypeName.equals("INT[]") || columnTypeName.equals("INTEGER[]")) {
+      } else if (columnTypeName.equals("LONG[]") || columnTypeName.equals("HUGEINT[]") || columnTypeName.equals("BIGINT[]") || columnTypeName.equals("INT[]") || columnTypeName.equals("INTEGER[]")) {
         return Lists.LongList.class;
       } else if (columnTypeName.equals("DATE[]")) {
         return Lists.LocalDateList.class;


### PR DESCRIPTION
With my DuckDB schema, the `columnTypeName` is sometimes `BIGINT[]`. This type should correspond to the SquashQL `Lists.LongList.class` list type, and not the default `List.class`.
Without this fix, queries using array contains statement with bigint arrays fail on DuckDB.